### PR TITLE
FIFF definitions

### DIFF
--- a/DictionaryTags_MNE.txt
+++ b/DictionaryTags_MNE.txt
@@ -175,11 +175,13 @@ mne_rt_command              3700 ? "realtime command"
 mne_rt_client_id            3701 ? "realtime client"
 
 #
-# 3710... MNE epochs bookkeeping
+# 3800... MNE epochs bookkeeping
 #
-mne_epochs_selection        3710 ? "the epochs selection"
-mne_epochs_drop_log         3711 ? "the drop log"
 
-#<reserved>		3712	-           "Reserved for MNE sw."
+mne_epochs_selection        3800 ? "the epochs selection"
+mne_epochs_drop_log         3801 ? "the drop log"
+
+mne_annotations             3810 ? "raw annotations"
+
 #...			...
-#<reserved>		3799    -           "Reserved for MNE sw."
+#<reserved>		3811    -   3999   "Reserved for MNE sw."


### PR DESCRIPTION
Here are the updated dictionaries. I just added the tag ids to the next available ones.

I didn't include the following:

```
#
# Additional coordinate frames
#
FIFF.FIFFV_MNE_COORD_TUFTS_EEG   =  300         # For Tufts EEG data
FIFF.FIFFV_MNE_COORD_CTF_DEVICE  = 1001         # CTF device coordinates
FIFF.FIFFV_MNE_COORD_CTF_HEAD    = 1004         # CTF head coordinates
FIFF.FIFFV_MNE_COORD_DIGITIZER   = FIFF.FIFFV_COORD_ISOTRAK # Original (Polhemus) digitizer coordinates
FIFF.FIFFV_MNE_COORD_SURFACE_RAS = FIFF.FIFFV_COORD_MRI     # The surface RAS coordinates
FIFF.FIFFV_MNE_COORD_MRI_VOXEL   = 2001         # The MRI voxel coordinates
FIFF.FIFFV_MNE_COORD_RAS         = 2002         # Surface RAS coordinates with non-zero origin
FIFF.FIFFV_MNE_COORD_MNI_TAL     = 2003         # MNI Talairach coordinates
FIFF.FIFFV_MNE_COORD_FS_TAL_GTZ  = 2004         # FreeSurfer Talairach coordinates (MNI z > 0)
FIFF.FIFFV_MNE_COORD_FS_TAL_LTZ  = 2005         # FreeSurfer Talairach coordinates (MNI z < 0)
FIFF.FIFFV_MNE_COORD_FS_TAL      = 2006         # FreeSurfer Talairach coordinates
#
# 4D and KIT use the same head coordinate system definition as CTF
#
FIFF.FIFFV_MNE_COORD_4D_HEAD     = FIFF.FIFFV_MNE_COORD_CTF_HEAD
FIFF.FIFFV_MNE_COORD_KIT_HEAD    = FIFF.FIFFV_MNE_COORD_CTF_HEAD
#
```

because I didn't know what they refer to and they're not used anywhere in the code AFAIK.

Ping @agramfort @Eric89GXL 
