### PR TITLE
Add "Other" sex option

### DIFF
--- a/DictionaryTypes.txt
+++ b/DictionaryTypes.txt
@@ -447,6 +447,7 @@ enum(sex) "Sex of a subject/patient"
     unknown     0    "Unknown gender"
     male	1    "Male"
     female	2    "Female"
+    other   3    "Other"
 }
 
 

--- a/DictionaryTypes.txt
+++ b/DictionaryTypes.txt
@@ -444,9 +444,9 @@ enum(cardinal_point_cardiac) "Cardinal point types for brain data"
 
 enum(sex) "Sex of a subject/patient"
 {
-    unknown     0    "Unknown gender"
-    male	1    "Male"
-    female	2    "Female"
+    unknown 0    "Unknown gender"
+    male    1    "Male"
+    female  2    "Female"
     other   3    "Other"
 }
 


### PR DESCRIPTION
As suggested in https://github.com/mne-tools/fiff-constants/issues/25#issuecomment-590406638

This also made me wonder why there's an "unknown" sex value, while we don't have that for any other personal information on the participant (e.g., handedness, height, weight, birthday… if we don't know them, they typically shouldn't be set, rigtht?)

Also, if anything, "Unknown gender" should be "Unknown sex" or just "Unknown", since we're talking about sex here and not gender… is it safe to change this?