### PR TITLE
ENH: Add mne_ch_name_mapping

### DIFF
--- a/DictionaryTags_MNE.txt
+++ b/DictionaryTags_MNE.txt
@@ -38,6 +38,7 @@ mne_coord_frame         3506    enum(?)   "Coordinate frame employed. Defaults:
                                                       * FIFFB_MNE_INVERSE_SOLUTION   FIFF_COORD_HEAD"
 mne_ch_name_list        3507   string
 mne_file_name           3508   string     ""    /* This removes the collision with fiff_file.h  (used to be 3501) */
+mne_ch_name_mapping     3509   string
 
 #
 # 3510... Source space


### PR DESCRIPTION
@jnenonen this PR adds a new tag to the MNE namespace to allow channel names longer than 15 characters by giving a JSON dictionary mapping between 15-char and arbitrary-length names. But before doing that, I thought I'd check to see if MEGIN folks would be interested in using this sort of functionality, in which case it could live in the main namespace. Quoting the [MNE issue](https://github.com/mne-tools/mne-python/issues/8312#issuecomment-700249945):

> The reason there is a limitation at all IIUC is beacuse the channel info struct is a fixed-size C struct. We could add a FIFFV_MNE_CHANNEL_NAMES_MAPPING tag as a string JSON dump of the dict mapping short-to-original names that has the following behavior:
>
> 1. When writing, (temporarily) replace info['chs'] and info['bads'] names with the shortened ones; write the FIFFV_MNE_CHANNEL_NAMES_MAPPING JSON
> 2. When reading, check for the presence of the FIFFV_MNE_CHANNEL_NAMES_MAPPING JSON and use it to make the appropriate substitutions in info['chs'] and info['bads'].
>
> In other words, we add a tag that says "do rename_channels(...) during writing and reading".

In theory this could be implemented in MEGIN C programs, too, but I assume it would be more of a pain because of structs/types/assumptions about these channel names.

Any interest in having this in the main DictionaryTags (e.g., if you think you would use it someday), or should we just keep it here in DictionaryTags_MNE.txt ?