### PR TITLE
add ch_type and coils for eye-tracker data

### DIFF
--- a/DictionaryTypes.txt
+++ b/DictionaryTypes.txt
@@ -218,6 +218,9 @@ enum(unit) "FIFF value unit code"
     Am		202	"Am"
     Am_m2	203	"Am/m^2"
     Am_m3	204	"Am/m^3"
+    Px      210 "px"
+    Deg     211 "deg"
+    mm      212 "mm"
 }
 
 enum(unitm) "FIFF value multipliers"

--- a/DictionaryTypes.txt
+++ b/DictionaryTypes.txt
@@ -219,8 +219,6 @@ enum(unit) "FIFF value unit code"
     Am_m2	203	"Am/m^2"
     Am_m3	204	"Am/m^3"
     Px      210 "px"
-    Deg     211 "deg"
-    mm      212 "mm"
 }
 
 enum(unitm) "FIFF value multipliers"

--- a/DictionaryTypes.txt
+++ b/DictionaryTypes.txt
@@ -276,6 +276,7 @@ enum(ch_type) "Type of the channel"
     fnirs	   1100		     "Functional near-infrared spectroscopy"
     temperature	   1200		     "Temperature"
     gsr		   1300		     "Galvanic skin response"
+    eyetrack   1400          "Eye-tracking"
 }
 
 
@@ -335,6 +336,8 @@ enum(coil) "Sensor coil type"
     kriss_grad		9001  "KRISS gradiometer"
     compumedics_adult_grad      9101  "Compumedics adult gradiometer"
     compumedics_pediatric_grad  9102  "Compumedics pediatric gradiometer"
+    eyetrack_pos    ????  "Eye-tracking gaze position"
+    eyetrack_pupil  ????  "Eye-tracking pupil size"
 }
 
 

--- a/DictionaryTypes.txt
+++ b/DictionaryTypes.txt
@@ -298,6 +298,8 @@ enum(coil) "Sensor coil type"
     fnirs_fd_phase             305  "fNIRS frequency domain phase"
     fnirs_td_gated_amplitude   306 "fNIRS time domain gated amplitude"
     fnirs_td_moments_amplitude 307 "fNIRS time domain moments amplitude"
+    eyetrack_pos    400  "Eye-tracking gaze position"
+    eyetrack_pupil  401  "Eye-tracking pupil size"
     mcg_42              1000  "For testing the MCG software"
     point_magnetometer  2000  "Simple point magnetometer"
     axial_grad_5cm      2001  "Generic axial gradiometer"
@@ -336,8 +338,6 @@ enum(coil) "Sensor coil type"
     kriss_grad		9001  "KRISS gradiometer"
     compumedics_adult_grad      9101  "Compumedics adult gradiometer"
     compumedics_pediatric_grad  9102  "Compumedics pediatric gradiometer"
-    eyetrack_pos    ????  "Eye-tracking gaze position"
-    eyetrack_pupil  ????  "Eye-tracking pupil size"
 }
 
 


### PR DESCRIPTION
hi all,

I'm working on basic eyetracker support for MNE (see https://github.com/mne-tools/mne-python/issues/10751 ).

therefor we should probably add a specific channel type to the FIF standard, as @larsoner mentioned..

are these the right changes, or did I miss a relevant location?
also, what is the logic behind the numbering system? so far I inserted `????`