### PR TITLE
ENH: Add BIDS standard types

### DIFF
--- a/DictionaryTypes.txt
+++ b/DictionaryTypes.txt
@@ -274,7 +274,7 @@ enum(ch_type) "Type of the channel"
     dipole_wave    1000		     "Dipole time curve"
     goodness_fit   1001		     "Goodness of fit"
     fnirs	   1100		     "Functional near-infrared spectroscopy"
-    temperature	   1200		     "Functional near-infrared spectroscopy"
+    temperature	   1200		     "Temperature"
     galvanic	   1300		     "Galvanic skin response"
 }
 

--- a/DictionaryTypes.txt
+++ b/DictionaryTypes.txt
@@ -275,7 +275,7 @@ enum(ch_type) "Type of the channel"
     goodness_fit   1001		     "Goodness of fit"
     fnirs	   1100		     "Functional near-infrared spectroscopy"
     temperature	   1200		     "Temperature"
-    galvanic	   1300		     "Galvanic skin response"
+    gsr		   1300		     "Galvanic skin response"
 }
 
 

--- a/DictionaryTypes.txt
+++ b/DictionaryTypes.txt
@@ -274,6 +274,8 @@ enum(ch_type) "Type of the channel"
     dipole_wave    1000		     "Dipole time curve"
     goodness_fit   1001		     "Goodness of fit"
     fnirs	   1100		     "Functional near-infrared spectroscopy"
+    temperature	   1200		     "Functional near-infrared spectroscopy"
+    galvanic	   1300		     "Galvanic skin response"
 }
 
 


### PR DESCRIPTION
Adds two new channel types:

1. galvanic skin response
2. temperature

Quoting @hoechenberger:

> BIDS spec:
> https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/03-electroencephalography.html#channels-description-_channelstsv
>
> Issue was discovered & discussed here:
> https://github.com/mne-tools/mne-bids/issues/1046